### PR TITLE
Refactor/#138 refactor skeleton & 테스트 커버리지 추가

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -2,7 +2,7 @@
 // 유용한 matcher들을 모든 테스트 파일에서 사용할 수 있게 합니다.
 import '@testing-library/jest-dom';
 
-process.env.NEXT_PUBLIC_TEAM_ID = '1';
+process.env.NEXT_PUBLIC_TEAM_ID = '10-6';
 
 jest.mock('@/i18n', () => ({
   // useRouter를 호출하면, 가짜 객체를 반환하도록 설정

--- a/src/app/[locale]/favorites/page.tsx
+++ b/src/app/[locale]/favorites/page.tsx
@@ -3,10 +3,10 @@
 import { Suspense } from 'react';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
-import { FavoritesList } from '@/entities/favorites/ui/FavoritesList';
 import { TypeFilterGroup } from '@/features/filters/ui/TypeFilterGroup';
 import { DoubleHeartIcon } from '@/shared/ui/icon';
 import { PageInfoLayout } from '@/shared/ui/pageInfoLayout';
+import { FavoritesList } from '@/widgets/FavoritesList/FavoritesList';
 import { FavoritesSkeletonList } from '@/widgets/FavoritesSkeleton';
 
 export default function FavoritesPage() {

--- a/src/entities/favorites/lib/favorite.test.ts
+++ b/src/entities/favorites/lib/favorite.test.ts
@@ -85,4 +85,31 @@ describe('fetchFavoritesData - 로컬 ID 배열 → 쉼표 문자열 → Gatheri
 
     consoleSpy.mockRestore();
   });
+
+  it('데이터 개수가 LIMIT와 같으면 다음 페이지가 존재', async () => {
+    const mockData = Array.from({ length: 10 }, (_, i) => ({ id: i + 1 }));
+    mockGetGatherings.mockResolvedValueOnce(mockData);
+
+    const result = await fetchFavoritesData({ ids: [1], type: 'MEET', pageParam: 5 });
+
+    expect(result.nextOffset).toBe(15); // 5 + 10
+  });
+
+  it('데이터 개수가 LIMIT와 같으면 다음 페이지가 존재하지 않는다 ', async () => {
+    const mockData = [{ id: 1 }, { id: 2 }];
+    mockGetGatherings.mockResolvedValueOnce(mockData);
+
+    const result = await fetchFavoritesData({ ids: [1], type: 'MEET', pageParam: 5 });
+
+    expect(result.nextOffset).toBeUndefined();
+  });
+
+  it('LIMIT와 동일한 개수의 데이터가 있을 때 pageParam이 20이면 nextOffset이 30이 된다', async () => {
+    const mockData = Array.from({ length: 10 }, (_, i) => ({ id: i + 1 }));
+    mockGetGatherings.mockResolvedValueOnce(mockData);
+
+    const result = await fetchFavoritesData({ ids: [1], type: 'MEET', pageParam: 20 });
+
+    expect(result.nextOffset).toBe(30); // 20 + 10
+  });
 });

--- a/src/features/favorites/model/favoritesStorage.test.ts
+++ b/src/features/favorites/model/favoritesStorage.test.ts
@@ -46,4 +46,64 @@ describe('로컬스토리지 찜 기능', () => {
     clearFavoriteList();
     expect(mockRemoveItem).toHaveBeenCalledWith(FAVORITES_KEY);
   });
+
+  it('getFavoriteList: JSON 파싱 실패 시 콘솔 에러 출력 후 빈 배열 반환', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetItem.mockReturnValueOnce('🙃 not-json 🙃'); // JSON.parse 에러 유도
+
+    const result = getFavoriteList();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '로컬 스토리지에서 찜 목록을 불러오는 데 실패했습니다:',
+      expect.any(SyntaxError),
+    );
+    expect(result).toEqual([]);
+    errorSpy.mockRestore();
+  });
+
+  it('toggleFavorite: setItem 예외 발생 시 콘솔 에러 출력', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    // 현재 목록은 빈 배열이라고 가정
+    mockGetItem.mockReturnValueOnce(JSON.stringify([]));
+    mockSetItem.mockImplementationOnce(() => {
+      throw new Error('QuotaExceededError');
+    });
+
+    // 예외는 내부에서 잡히므로 호출 자체는 던지지 않음
+    toggleFavorite(1);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '로컬 스토리지에 찜 목록을 저장하는 데 실패했습니다:',
+      expect.any(Error),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it('clearFavoriteList: removeItem 예외 발생 시 콘솔 에러 출력', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockRemoveItem.mockImplementationOnce(() => {
+      throw new Error('PermissionDenied');
+    });
+
+    clearFavoriteList();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '로컬 스토리지에서 찜 목록을 삭제하는 데 실패했습니다:',
+      expect.any(Error),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it('getFavoriteList: window가 없는 환경에서는 빈 배열을 반환한다', () => {
+    const originalWindow = global.window;
+    // window를 undefined로 설정 (SSR 시뮬레이션)
+    // @ts-expect-error 테스트를 위해 window를 제거
+    delete global.window;
+
+    const result = getFavoriteList();
+    expect(result).toEqual([]);
+
+    // 원래 상태로 복원
+    global.window = originalWindow;
+  });
 });

--- a/src/features/favorites/model/favoritesStorage.test.ts
+++ b/src/features/favorites/model/favoritesStorage.test.ts
@@ -96,14 +96,16 @@ describe('로컬스토리지 찜 기능', () => {
 
   it('getFavoriteList: window가 없는 환경에서는 빈 배열을 반환한다', () => {
     const originalWindow = global.window;
-    // window를 undefined로 설정 (SSR 시뮬레이션)
-    // @ts-expect-error 테스트를 위해 window를 제거
-    delete global.window;
+    try {
+      // window를 undefined로 설정 (SSR 시뮬레이션)
+      // @ts-expect-error 테스트를 위해 window를 제거
+      delete global.window;
 
-    const result = getFavoriteList();
-    expect(result).toEqual([]);
-
-    // 원래 상태로 복원
-    global.window = originalWindow;
+      const result = getFavoriteList();
+      expect(result).toEqual([]);
+    } finally {
+      // 원래 상태로 복원
+      global.window = originalWindow;
+    }
   });
 });

--- a/src/features/filters/ui/DateFilter.test.tsx
+++ b/src/features/filters/ui/DateFilter.test.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DateFilter } from './DateFilter';
+
+// -------------------- Router & SearchParams Mocks --------------------
+const mockPush = jest.fn();
+const mockPathName = jest.fn();
+const mockUseSearchParams = jest.fn();
+
+// next/navigation: useSearchParams만 사용
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => mockUseSearchParams(),
+}));
+
+// 커스텀 라우터 훅
+jest.mock('@/i18n', () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => mockPathName(),
+}));
+
+// -------------------- UI / Intl Mocks --------------------
+// Calendar: 간단 mock (날짜 픽 버튼 + footer 렌더)
+jest.mock('@/shared/ui/calendar/Calendar', () => ({
+  Calendar: ({
+    onChange,
+    footer,
+    className,
+  }: {
+    onChange?: (d?: Date) => void;
+    footer?: React.ReactNode;
+    className?: string;
+  }) => (
+    <div
+      data-testid="calendar"
+      className={className}
+    >
+      <button onClick={() => onChange?.(new Date(2025, 7, 10))}>pick-2025-08-10</button>
+      {footer}
+    </div>
+  ),
+}));
+
+// Button: 네이티브 버튼으로 대체
+jest.mock('@/shared/ui/button', () => ({
+  Button: (props: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props} />,
+}));
+
+// variants: className passthrough
+jest.mock('@/shared/ui/filter/variants', () => ({
+  filterButtonVariants: ({ className }: { className?: string }) => className ?? '',
+}));
+
+// icons: 단순 스팬
+jest.mock('@/shared/ui/icon', () => ({
+  ArrowDownIcon: () => <span>arrow-down</span>,
+  ArrowUpIcon: () => <span>arrow-up</span>,
+  WhiteArrowDownIcon: () => <span>white-arrow</span>,
+}));
+
+// next-intl: t는 default 우선 반환, locale은 ko-KR
+jest.mock('next-intl', () => ({
+  useTranslations: () => (_: string, opts?: { default?: string }) => opts?.default ?? '',
+  useLocale: () => 'ko-KR',
+}));
+
+// -------------------- Helpers --------------------
+const setSearchParams = (obj: Record<string, string | undefined>) => {
+  const sp = new URLSearchParams();
+  Object.entries(obj).forEach(([k, v]) => {
+    if (v !== undefined) sp.set(k, v);
+  });
+  mockUseSearchParams.mockReturnValue(sp);
+};
+
+const setPath = (path: string) => {
+  mockPathName.mockReturnValue(path);
+};
+
+const openCalendar = async () => {
+  const btn = screen.getByRole('button', { name: /전체 날짜|2025|date\.all/i });
+  await userEvent.click(btn);
+};
+
+// -------------------- Tests --------------------
+describe('<DateFilter />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setSearchParams({}); // 기본: date 없음
+    setPath('/gathering'); // 기본 경로
+  });
+
+  it('초기: date 파라미터가 없으면 "전체 날짜"가 보인다', () => {
+    render(<DateFilter />);
+    expect(screen.getByRole('button', { name: /전체 날짜/ })).toBeInTheDocument();
+  });
+
+  it('초기: date 파라미터가 있으면 해당 날짜(로케일 형식)로 표시된다', () => {
+    setSearchParams({ date: '2025-08-09' });
+    render(<DateFilter />);
+    // ko-KR 포맷(환경마다 공백/마침표 차이 있을 수 있어 느슨한 정규식)
+    expect(screen.getByRole('button', { name: /2025.*08.*09/ })).toBeInTheDocument();
+  });
+
+  it('버튼 클릭 시 캘린더 팝업이 열린다', async () => {
+    render(<DateFilter />);
+    expect(screen.queryByTestId('calendar')).not.toBeInTheDocument();
+
+    await openCalendar();
+    expect(screen.getByTestId('calendar')).toBeInTheDocument();
+  });
+
+  it('캘린더 외부 클릭 시 팝업이 닫힌다', async () => {
+    render(<DateFilter />);
+    await openCalendar();
+    expect(screen.getByTestId('calendar')).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByTestId('calendar')).not.toBeInTheDocument();
+  });
+
+  it('날짜 선택 후 "적용"하면 YYYY-MM-DD로 query 설정되어 push된다', async () => {
+    render(<DateFilter />);
+    await openCalendar();
+
+    await userEvent.click(screen.getByRole('button', { name: 'pick-2025-08-10' }));
+    await userEvent.click(screen.getByRole('button', { name: '적용' }));
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    const arg = mockPush.mock.calls[0][0];
+
+    expect(arg.pathname).toBe('/gathering');
+    expect(arg.query.date).toBe('2025-08-10');
+  });
+
+  it('초기화 클릭 시 date 파라미터 제거, 다른 쿼리는 유지된 상태로 push된다', async () => {
+    setSearchParams({ date: '2025-08-01', foo: 'bar' });
+    render(<DateFilter />);
+    await openCalendar();
+
+    await userEvent.click(screen.getByRole('button', { name: '초기화' }));
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    const arg = mockPush.mock.calls[0][0];
+
+    expect(arg.pathname).toBe('/gathering');
+    expect(arg.query.date).toBeUndefined();
+    expect(arg.query.foo).toBe('bar');
+  });
+
+  it('이미 선택된 날짜가 있을 때 팝업 열고 바로 "적용"해도 동일 날짜로 push된다( tempDate 시드 확인 )', async () => {
+    setSearchParams({ date: '2025-08-01' });
+    render(<DateFilter />);
+    await openCalendar();
+
+    // 날짜 재선택 없이 적용
+    await userEvent.click(screen.getByRole('button', { name: '적용' }));
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    const arg = mockPush.mock.calls[0][0];
+
+    expect(arg.query.date).toBe('2025-08-01');
+  });
+
+  it('적용/초기화 후 팝업은 닫힌다', async () => {
+    render(<DateFilter />);
+    await openCalendar();
+
+    // 적용 후 닫힘
+    await userEvent.click(screen.getByRole('button', { name: 'pick-2025-08-10' }));
+    await userEvent.click(screen.getByRole('button', { name: '적용' }));
+    expect(screen.queryByTestId('calendar')).not.toBeInTheDocument();
+
+    // 다시 열고 초기화 후 닫힘
+    await openCalendar();
+    await userEvent.click(screen.getByRole('button', { name: '초기화' }));
+    expect(screen.queryByTestId('calendar')).not.toBeInTheDocument();
+  });
+});

--- a/src/shared/ui/modal/BasicModal.test.tsx
+++ b/src/shared/ui/modal/BasicModal.test.tsx
@@ -71,4 +71,31 @@ describe('BasicModal 컴포넌트', () => {
     // 이 버튼 클릭이 모달을 닫는 onClose와는 관계 없는지 확인
     expect(defaultProps.onClose).not.toHaveBeenCalled();
   });
+
+  it('모달 열릴 때 body와 header 컨테이너 margin-right가 scrollbarWidth만큼 설정된다', () => {
+    // 가짜 헤더 컨테이너 추가
+    const headerDiv = document.createElement('div');
+    const header = document.createElement('header');
+    header.appendChild(headerDiv);
+    document.body.appendChild(header);
+
+    // 스크롤바 너비 시뮬레이션
+    Object.defineProperty(window, 'innerWidth', { value: 1200, writable: true });
+    Object.defineProperty(document.documentElement, 'clientWidth', { value: 1180, writable: true });
+    Object.defineProperty(document.documentElement, 'scrollHeight', {
+      value: 2000,
+      writable: true,
+    });
+    Object.defineProperty(document.documentElement, 'clientHeight', {
+      value: 1000,
+      writable: true,
+    });
+
+    render(<BasicModal {...defaultProps} />);
+
+    const expectedWidth = window.innerWidth - document.documentElement.clientWidth;
+    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.body.style.marginRight).toBe(`${expectedWidth}px`);
+    expect(headerDiv.style.marginRight).toBe(`${expectedWidth}px`);
+  });
 });

--- a/src/shared/ui/modal/BasicModal.test.tsx
+++ b/src/shared/ui/modal/BasicModal.test.tsx
@@ -71,31 +71,4 @@ describe('BasicModal 컴포넌트', () => {
     // 이 버튼 클릭이 모달을 닫는 onClose와는 관계 없는지 확인
     expect(defaultProps.onClose).not.toHaveBeenCalled();
   });
-
-  it('모달 열릴 때 body와 header 컨테이너 margin-right가 scrollbarWidth만큼 설정된다', () => {
-    // 가짜 헤더 컨테이너 추가
-    const headerDiv = document.createElement('div');
-    const header = document.createElement('header');
-    header.appendChild(headerDiv);
-    document.body.appendChild(header);
-
-    // 스크롤바 너비 시뮬레이션
-    Object.defineProperty(window, 'innerWidth', { value: 1200, writable: true });
-    Object.defineProperty(document.documentElement, 'clientWidth', { value: 1180, writable: true });
-    Object.defineProperty(document.documentElement, 'scrollHeight', {
-      value: 2000,
-      writable: true,
-    });
-    Object.defineProperty(document.documentElement, 'clientHeight', {
-      value: 1000,
-      writable: true,
-    });
-
-    render(<BasicModal {...defaultProps} />);
-
-    const expectedWidth = window.innerWidth - document.documentElement.clientWidth;
-    expect(document.body.style.overflow).toBe('hidden');
-    expect(document.body.style.marginRight).toBe(`${expectedWidth}px`);
-    expect(headerDiv.style.marginRight).toBe(`${expectedWidth}px`);
-  });
 });

--- a/src/shared/ui/pagination/Pagination.test.tsx
+++ b/src/shared/ui/pagination/Pagination.test.tsx
@@ -76,4 +76,36 @@ describe('페이지네이션에 관한 테스트', () => {
     );
     expect(screen.getAllByText('...')).toHaveLength(2);
   });
+
+  it('이전 버튼 클릭 시 onPageChange가 currentPage - 1로 호출되는가?', async () => {
+    const user = userEvent.setup();
+    render(
+      <Pagination
+        currentPage={3}
+        totalPages={5}
+        onPageChange={mockChange}
+      />,
+    );
+
+    const prevBtn = screen.getByLabelText('이전 페이지');
+    await user.click(prevBtn);
+    expect(mockChange).toHaveBeenCalledTimes(1);
+    expect(mockChange).toHaveBeenCalledWith(2); // 3 - 1
+  });
+
+  it('다음 버튼 클릭 시 onPageChange가 currentPage + 1로 호출되는가?', async () => {
+    const user = userEvent.setup();
+    render(
+      <Pagination
+        currentPage={3}
+        totalPages={5}
+        onPageChange={mockChange}
+      />,
+    );
+
+    const nextBtn = screen.getByLabelText('다음 페이지');
+    await user.click(nextBtn);
+    expect(mockChange).toHaveBeenCalledTimes(1);
+    expect(mockChange).toHaveBeenCalledWith(4); // 3 + 1
+  });
 });

--- a/src/widgets/FavoritesList/FavoritesList.tsx
+++ b/src/widgets/FavoritesList/FavoritesList.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl';
 import { getFavoriteList } from '@/features/favorites/model/favoritesStorage';
 import { InfiniteScrollObserver } from '@/shared/ui/InfiniteScrollObserver/InfiniteScrollObserver';
 import { GatheringCard } from '@/widgets/GatheringCard/ui';
-import { useGetFavoritesGathering } from '../api/queries';
+import { useGetFavoritesGathering } from '../../entities/favorites/api/queries';
 
 interface FavoritesListProps {
   type: string;

--- a/src/widgets/FavoritesList/FavoritesList.tsx
+++ b/src/widgets/FavoritesList/FavoritesList.tsx
@@ -35,7 +35,7 @@ export const FavoritesList = ({ type }: FavoritesListProps) => {
   return (
     <>
       <div className="w-full">
-        <div className="w-full space-y-4">
+        <div className="flex w-full flex-col gap-4">
           {allGatherings.length > 0 ? (
             allGatherings.map((gathering) => (
               <GatheringCard

--- a/src/widgets/FavoritesSkeleton/ui/FavoritesSkeletonCard.tsx
+++ b/src/widgets/FavoritesSkeleton/ui/FavoritesSkeletonCard.tsx
@@ -1,13 +1,26 @@
 export const FavoritesSkeletonCard = () => (
-  <div className="flex w-full animate-pulse gap-4 rounded-xl bg-gray-100 p-2 shadow-sm">
+  <div className="rounded-common tablet:flex-row relative flex w-full animate-pulse flex-col gap-1 overflow-hidden p-2 shadow-sm">
     {/* 이미지 부분 */}
-    <div className="h-40 w-40 flex-shrink-0 rounded-lg bg-gray-300" />
+    <div className="tablet:w-[280px] relative w-full bg-gray-200">
+      <div className="tablet:h-[160px] h-40 w-full"></div>
+    </div>
 
     {/* 텍스트 부분 */}
-    <div className="flex flex-1 flex-col justify-between space-y-2">
-      <div className="h-10 w-3/4 rounded bg-gray-300" />
-      <div className="h-10 w-1/2 rounded bg-gray-300" />
-      <div className="h-10 w-2/3 rounded bg-gray-300" />
+    <div className="flex flex-1 flex-col justify-between gap-4 p-4">
+      <div className="tablet:flex-row flex flex-col items-start justify-between gap-2">
+        <div className="flex w-full flex-col gap-3">
+          <div className="h-5 w-3/4 rounded bg-gray-200" />
+          <div className="h-5 w-1/2 rounded bg-gray-200" />
+        </div>
+        <div className="h-8 w-8 rounded-full bg-gray-200"></div>
+      </div>
+      <div className="flex w-full items-end gap-2">
+        <div className="flex flex-col">
+          <div className="h-2 w-1/4 rounded bg-gray-200" />
+          <div className="h-2 w-full rounded bg-gray-200" />
+        </div>
+        <div className="h-8 w-24 rounded bg-gray-200" />
+      </div>
     </div>
   </div>
 );


### PR DESCRIPTION
# 관련 이슈

Closes #138

## 📢 변경 사항

- 찜페이지 ui 스켈레톤 변경 
- 테스트 커버리지 보완
- 테스트 코드 추가 생성 

## 💬 그 외

- jset.jsetup 팀 아이디 변경 
- 주말에 오류 잡는다고 이것저것 만지다가 같이 올라간거같습니다 
- 10-6으로 그냥 둘까요 다시 1로 할까요? 

## 📷 스크린샷 (선택)

## ❓ 질문 사항

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 해당 없음
- 스타일
  - 즐겨찾기 목록 레이아웃을 개선해 일관된 간격과 컬럼 정렬을 제공.
  - 즐겨찾기 스켈레톤 카드를 반응형 구조로 개편하고 가독성 높은 플레이스홀더로 업데이트.
- 리팩터
  - 즐겨찾기 관련 컴포넌트 구조를 정리하여 경로를 정돈.
- 테스트
  - 즐겨찾기 데이터 페이지네이션, 스토리지 오류/SSR 처리, 날짜 필터 동작/로케일 표시, 페이지네이션 내비게이션에 대한 테스트 추가.
- 작업
  - 테스트 환경 변수 구성 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->