### PR TITLE
fix: 리뷰카드 시간 변경 / 불필요한 suspense 제거

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -2,7 +2,7 @@
 // 유용한 matcher들을 모든 테스트 파일에서 사용할 수 있게 합니다.
 import '@testing-library/jest-dom';
 
-process.env.NEXT_PUBLIC_TEAM_ID = '10-6';
+process.env.NEXT_PUBLIC_TEAM_ID = '1';
 
 jest.mock('@/i18n', () => ({
   // useRouter를 호출하면, 가짜 객체를 반환하도록 설정

--- a/src/app/[locale]/reviews/page.tsx
+++ b/src/app/[locale]/reviews/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import { Locale } from 'next-intl';
 import { getMessages, getTranslations } from 'next-intl/server';
@@ -61,20 +60,16 @@ export default async function ReviewsPage({ params, searchParams }: ReviewsPageP
 
       <TypeFilterGroup />
       <HydrationProvider dehydratedState={dehydrate(queryClient)}>
-        <Suspense fallback={t('loading')}>
-          <AllReviewRating type={reviewParams.type} />
-        </Suspense>
+        <AllReviewRating type={reviewParams.type} />
         <div className="mb-4 flex items-center justify-between">
           <OptionsFiltersGroup
             sortValue={sortOptions}
             defaultSort="createdAt"
           />
         </div>
-        <Suspense fallback={t('loading')}>
-          <div className="mt-8 min-h-[28rem]">
-            <ReviewList filters={reviewParams} />
-          </div>
-        </Suspense>
+        <div className="mt-8 min-h-[28rem]">
+          <ReviewList filters={reviewParams} />
+        </div>
       </HydrationProvider>
     </div>
   );

--- a/src/widgets/ReviewList/ui/ReviewList.tsx
+++ b/src/widgets/ReviewList/ui/ReviewList.tsx
@@ -39,7 +39,7 @@ export const ReviewList = ({ filters }: ReviewListProps) => {
               <ReviewCard
                 score={review.score}
                 comment={review.comment}
-                dateTime={review.createdAt}
+                dateTime={review.Gathering?.dateTime}
                 userName={review.User?.name}
                 userImg={review.User?.image}
                 reviewImg={review.Gathering?.image}


### PR DESCRIPTION
# 관련 이슈

Closes #155

## 📢 변경 사항

- 리뷰 페이지, 날짜 필터링 선택된 날짜와 실제 목록의 날짜 차이 해결
- 리뷰 날짜, 생성 날짜에서 모임 날자로 교체 

## 💬 그 외

-리뷰페이지 서스펜스 제거 

## 📷 스크린샷 (선택)

## ❓ 질문 사항

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 리뷰 카드의 날짜 표기가 작성일 대신 모임(행사) 일시를 사용하도록 조정되어 실제 일정과 일치합니다.

- **리팩터링**
  - 리뷰 페이지에서 로딩 문구가 제거되어 콘텐츠가 바로 렌더링됩니다.

- **테스트**
  - 테스트 환경 변수(NEXT_PUBLIC_TEAM_ID) 값을 업데이트하여 테스트 초기화 설정을 정비했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->